### PR TITLE
`Hashable` and `Identifiable`

### DIFF
--- a/scripts/tl2swift/Sources/TlParserLib/Composer/EnumComposer.swift
+++ b/scripts/tl2swift/Sources/TlParserLib/Composer/EnumComposer.swift
@@ -35,7 +35,7 @@ final class EnumComposer: Composer {
         
         return ""
             .addLine("/// \(enumInfo.description)")
-            .addLine("public \(indirect)enum \(enumInfo.enumType): Codable, Equatable {")
+            .addLine("public \(indirect)enum \(enumInfo.enumType): Codable, Equatable, Hashable {")
             .addBlankLine()
             .append(cases.indent())
             .addBlankLine()

--- a/scripts/tl2swift/Sources/TlParserLib/Composer/StructComposer.swift
+++ b/scripts/tl2swift/Sources/TlParserLib/Composer/StructComposer.swift
@@ -93,7 +93,7 @@ final class StructComposer: Composer {
     }
     
     private func protocolConformance(for structName: String) -> String {
-        var protocols = ["Codable", "Equatable"]
+        var protocols = ["Codable", "Equatable", "Hashable"]
         if structName == "Error" {
             protocols.append("Swift.Error")
         }

--- a/scripts/tl2swift/Sources/TlParserLib/Composer/StructComposer.swift
+++ b/scripts/tl2swift/Sources/TlParserLib/Composer/StructComposer.swift
@@ -32,7 +32,7 @@ final class StructComposer: Composer {
     
     private func composeStruct(classInfo: ClassInfo) -> String {
         let structName = classInfo.name.capitalizedFirstLetter
-        let protocols = protocolConformance(for: structName)
+        let protocols = protocolConformance(for: structName, using: classInfo.properties)
         let props = composeStructProperties(classInfo.properties)
         let structInit = composeInit(classInfo.properties)
         return ""
@@ -92,8 +92,11 @@ final class StructComposer: Composer {
         return result.addLine("}")
     }
     
-    private func protocolConformance(for structName: String) -> String {
+    private func protocolConformance(for structName: String, using properties: [ClassProperty]) -> String {
         var protocols = ["Codable", "Equatable", "Hashable"]
+        if properties.map(\.name).contains("id") {
+            protocols.append("Identifiable")
+        }
         if structName == "Error" {
             protocols.append("Swift.Error")
         }

--- a/scripts/tl2swift/Sources/TlParserLib/Composer/Supporting/TdInt64Composer.swift
+++ b/scripts/tl2swift/Sources/TlParserLib/Composer/Supporting/TdInt64Composer.swift
@@ -12,7 +12,7 @@ final class TdInt64Composer: Composer {
     
     override func composeUtilitySourceCode() throws -> String {
         return ""
-            .addLine("public struct TdInt64: RawRepresentable, ExpressibleByIntegerLiteral {")
+            .addLine("public struct TdInt64: RawRepresentable, ExpressibleByIntegerLiteral, Hashable {")
             .addBlankLine()
             .addLine("    public typealias RawValue = Int64")
             .addBlankLine()


### PR DESCRIPTION
I don't see any problems with adding Hashable protocol conformance, even to the TdInt64, that should be ok.

Identifiable is a bit more complicated:
I've checked all the structs that now gets Identifiable conformance and most of them mention, that `id` is "Unique", but some of them don't, even if it is an identifier of the User struct, that must be unique AFAIK.

I see two possible variants to deal with Identifiable:
1. Add Identifiable conformance, only if the `id` is mentioned in the comment as "Unique".
2. Leave the uniqueness to the developers.

I would prefer the second variant.