### PR TITLE
Detect optional parameters that have "pass null" in their description

### DIFF
--- a/Sources/TDLibKit/Generated/Models/InputIdentityDocument.swift
+++ b/Sources/TDLibKit/Generated/Models/InputIdentityDocument.swift
@@ -14,7 +14,7 @@ import Foundation
 public struct InputIdentityDocument: Codable, Equatable, Hashable {
 
     /// Document expiry date; pass null if not applicable
-    public let expiryDate: Date
+    public let expiryDate: Date?
 
     /// Front side of the document
     public let frontSide: InputFile
@@ -23,21 +23,21 @@ public struct InputIdentityDocument: Codable, Equatable, Hashable {
     public let number: String
 
     /// Reverse side of the document; only for driver license and identity card; pass null otherwise
-    public let reverseSide: InputFile
+    public let reverseSide: InputFile?
 
     /// Selfie with the document; pass null if unavailable
-    public let selfie: InputFile
+    public let selfie: InputFile?
 
     /// List of files containing a certified English translation of the document
     public let translation: [InputFile]
 
 
     public init(
-        expiryDate: Date,
+        expiryDate: Date?,
         frontSide: InputFile,
         number: String,
-        reverseSide: InputFile,
-        selfie: InputFile,
+        reverseSide: InputFile?,
+        selfie: InputFile?,
         translation: [InputFile]
     ) {
         self.expiryDate = expiryDate

--- a/Sources/TDLibKit/Generated/Models/InputInlineQueryResult.swift
+++ b/Sources/TDLibKit/Generated/Models/InputInlineQueryResult.swift
@@ -161,7 +161,7 @@ public struct InputInlineQueryResultAnimation: Codable, Equatable, Hashable, Ide
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// MIME type of the video thumbnail. If non-empty, must be one of "image/jpeg", "image/gif" and "video/mp4"
     public let thumbnailMimeType: String
@@ -191,7 +191,7 @@ public struct InputInlineQueryResultAnimation: Codable, Equatable, Hashable, Ide
     public init(
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailMimeType: String,
         thumbnailUrl: String,
         title: String,
@@ -230,7 +230,7 @@ public struct InputInlineQueryResultArticle: Codable, Equatable, Hashable, Ident
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Thumbnail height, if known
     public let thumbnailHeight: Int
@@ -253,7 +253,7 @@ public struct InputInlineQueryResultArticle: Codable, Equatable, Hashable, Ident
         hideUrl: Bool,
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailHeight: Int,
         thumbnailUrl: String,
         thumbnailWidth: Int,
@@ -292,7 +292,7 @@ public struct InputInlineQueryResultAudio: Codable, Equatable, Hashable, Identif
     public let performer: String
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Title of the audio file
     public let title: String
@@ -304,7 +304,7 @@ public struct InputInlineQueryResultAudio: Codable, Equatable, Hashable, Identif
         id: String,
         inputMessageContent: InputMessageContent,
         performer: String,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         title: String
     ) {
         self.audioDuration = audioDuration
@@ -330,7 +330,7 @@ public struct InputInlineQueryResultContact: Codable, Equatable, Hashable, Ident
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Thumbnail height, if known
     public let thumbnailHeight: Int
@@ -346,7 +346,7 @@ public struct InputInlineQueryResultContact: Codable, Equatable, Hashable, Ident
         contact: Contact,
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailHeight: Int,
         thumbnailUrl: String,
         thumbnailWidth: Int
@@ -379,7 +379,7 @@ public struct InputInlineQueryResultDocument: Codable, Equatable, Hashable, Iden
     public let mimeType: String
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Height of the thumbnail
     public let thumbnailHeight: Int
@@ -400,7 +400,7 @@ public struct InputInlineQueryResultDocument: Codable, Equatable, Hashable, Iden
         id: String,
         inputMessageContent: InputMessageContent,
         mimeType: String,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailHeight: Int,
         thumbnailUrl: String,
         thumbnailWidth: Int,
@@ -429,13 +429,13 @@ public struct InputInlineQueryResultGame: Codable, Equatable, Hashable, Identifi
     public let id: String
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
 
     public init(
         gameShortName: String,
         id: String,
-        replyMarkup: ReplyMarkup
+        replyMarkup: ReplyMarkup?
     ) {
         self.gameShortName = gameShortName
         self.id = id
@@ -459,7 +459,7 @@ public struct InputInlineQueryResultLocation: Codable, Equatable, Hashable, Iden
     public let location: Location
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Thumbnail height, if known
     public let thumbnailHeight: Int
@@ -479,7 +479,7 @@ public struct InputInlineQueryResultLocation: Codable, Equatable, Hashable, Iden
         inputMessageContent: InputMessageContent,
         livePeriod: Int,
         location: Location,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailHeight: Int,
         thumbnailUrl: String,
         thumbnailWidth: Int,
@@ -518,7 +518,7 @@ public struct InputInlineQueryResultPhoto: Codable, Equatable, Hashable, Identif
     public let photoWidth: Int
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// URL of the photo thumbnail, if it exists
     public let thumbnailUrl: String
@@ -534,7 +534,7 @@ public struct InputInlineQueryResultPhoto: Codable, Equatable, Hashable, Identif
         photoHeight: Int,
         photoUrl: String,
         photoWidth: Int,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailUrl: String,
         title: String
     ) {
@@ -560,7 +560,7 @@ public struct InputInlineQueryResultSticker: Codable, Equatable, Hashable, Ident
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Height of the sticker
     public let stickerHeight: Int
@@ -578,7 +578,7 @@ public struct InputInlineQueryResultSticker: Codable, Equatable, Hashable, Ident
     public init(
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         stickerHeight: Int,
         stickerUrl: String,
         stickerWidth: Int,
@@ -604,7 +604,7 @@ public struct InputInlineQueryResultVenue: Codable, Equatable, Hashable, Identif
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Thumbnail height, if known
     public let thumbnailHeight: Int
@@ -622,7 +622,7 @@ public struct InputInlineQueryResultVenue: Codable, Equatable, Hashable, Identif
     public init(
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailHeight: Int,
         thumbnailUrl: String,
         thumbnailWidth: Int,
@@ -653,7 +653,7 @@ public struct InputInlineQueryResultVideo: Codable, Equatable, Hashable, Identif
     public let mimeType: String
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// The URL of the video thumbnail (JPEG), if it exists
     public let thumbnailUrl: String
@@ -679,7 +679,7 @@ public struct InputInlineQueryResultVideo: Codable, Equatable, Hashable, Identif
         id: String,
         inputMessageContent: InputMessageContent,
         mimeType: String,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         thumbnailUrl: String,
         title: String,
         videoDuration: Int,
@@ -711,7 +711,7 @@ public struct InputInlineQueryResultVoiceNote: Codable, Equatable, Hashable, Ide
     public let inputMessageContent: InputMessageContent
 
     /// The message reply markup; pass null if none. Must be of type replyMarkupInlineKeyboard or null
-    public let replyMarkup: ReplyMarkup
+    public let replyMarkup: ReplyMarkup?
 
     /// Title of the voice note
     public let title: String
@@ -726,7 +726,7 @@ public struct InputInlineQueryResultVoiceNote: Codable, Equatable, Hashable, Ide
     public init(
         id: String,
         inputMessageContent: InputMessageContent,
-        replyMarkup: ReplyMarkup,
+        replyMarkup: ReplyMarkup?,
         title: String,
         voiceNoteDuration: Int,
         voiceNoteUrl: String

--- a/Sources/TDLibKit/Generated/Models/InputMessageContent.swift
+++ b/Sources/TDLibKit/Generated/Models/InputMessageContent.swift
@@ -235,7 +235,7 @@ public struct InputMessageAnimation: Codable, Equatable, Hashable {
     public let animation: InputFile
 
     /// Animation caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// Duration of the animation, in seconds
     public let duration: Int
@@ -247,7 +247,7 @@ public struct InputMessageAnimation: Codable, Equatable, Hashable {
     public let height: Int
 
     /// Animation thumbnail; pass null to skip thumbnail uploading
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
     /// Width of the animation; may be replaced by the server
     public let width: Int
@@ -256,11 +256,11 @@ public struct InputMessageAnimation: Codable, Equatable, Hashable {
     public init(
         addedStickerFileIds: [Int],
         animation: InputFile,
-        caption: FormattedText,
+        caption: FormattedText?,
         duration: Int,
         hasSpoiler: Bool,
         height: Int,
-        thumbnail: InputThumbnail,
+        thumbnail: InputThumbnail?,
         width: Int
     ) {
         self.addedStickerFileIds = addedStickerFileIds
@@ -278,13 +278,13 @@ public struct InputMessageAnimation: Codable, Equatable, Hashable {
 public struct InputMessageAudio: Codable, Equatable, Hashable {
 
     /// Thumbnail of the cover for the album; pass null to skip thumbnail uploading
-    public let albumCoverThumbnail: InputThumbnail
+    public let albumCoverThumbnail: InputThumbnail?
 
     /// Audio file to be sent
     public let audio: InputFile
 
     /// Audio caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// Duration of the audio, in seconds; may be replaced by the server
     public let duration: Int
@@ -297,9 +297,9 @@ public struct InputMessageAudio: Codable, Equatable, Hashable {
 
 
     public init(
-        albumCoverThumbnail: InputThumbnail,
+        albumCoverThumbnail: InputThumbnail?,
         audio: InputFile,
-        caption: FormattedText,
+        caption: FormattedText?,
         duration: Int,
         performer: String,
         title: String
@@ -317,7 +317,7 @@ public struct InputMessageAudio: Codable, Equatable, Hashable {
 public struct InputMessageDocument: Codable, Equatable, Hashable {
 
     /// Document caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// If true, automatic file type detection will be disabled and the document will always be sent as file. Always true for files sent to secret chats
     public let disableContentTypeDetection: Bool
@@ -326,14 +326,14 @@ public struct InputMessageDocument: Codable, Equatable, Hashable {
     public let document: InputFile
 
     /// Document thumbnail; pass null to skip thumbnail uploading
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
 
     public init(
-        caption: FormattedText,
+        caption: FormattedText?,
         disableContentTypeDetection: Bool,
         document: InputFile,
-        thumbnail: InputThumbnail
+        thumbnail: InputThumbnail?
     ) {
         self.caption = caption
         self.disableContentTypeDetection = disableContentTypeDetection
@@ -349,7 +349,7 @@ public struct InputMessagePhoto: Codable, Equatable, Hashable {
     public let addedStickerFileIds: [Int]
 
     /// Photo caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// True, if the photo preview must be covered by a spoiler animation; not supported in secret chats
     public let hasSpoiler: Bool
@@ -364,7 +364,7 @@ public struct InputMessagePhoto: Codable, Equatable, Hashable {
     public let selfDestructTime: Int
 
     /// Photo thumbnail to be sent; pass null to skip thumbnail uploading. The thumbnail is sent to the other party only in secret chats
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
     /// Photo width
     public let width: Int
@@ -372,12 +372,12 @@ public struct InputMessagePhoto: Codable, Equatable, Hashable {
 
     public init(
         addedStickerFileIds: [Int],
-        caption: FormattedText,
+        caption: FormattedText?,
         hasSpoiler: Bool,
         height: Int,
         photo: InputFile,
         selfDestructTime: Int,
-        thumbnail: InputThumbnail,
+        thumbnail: InputThumbnail?,
         width: Int
     ) {
         self.addedStickerFileIds = addedStickerFileIds
@@ -404,7 +404,7 @@ public struct InputMessageSticker: Codable, Equatable, Hashable {
     public let sticker: InputFile
 
     /// Sticker thumbnail; pass null to skip thumbnail uploading
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
     /// Sticker width
     public let width: Int
@@ -414,7 +414,7 @@ public struct InputMessageSticker: Codable, Equatable, Hashable {
         emoji: String,
         height: Int,
         sticker: InputFile,
-        thumbnail: InputThumbnail,
+        thumbnail: InputThumbnail?,
         width: Int
     ) {
         self.emoji = emoji
@@ -432,7 +432,7 @@ public struct InputMessageVideo: Codable, Equatable, Hashable {
     public let addedStickerFileIds: [Int]
 
     /// Video caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// Duration of the video, in seconds
     public let duration: Int
@@ -450,7 +450,7 @@ public struct InputMessageVideo: Codable, Equatable, Hashable {
     public let supportsStreaming: Bool
 
     /// Video thumbnail; pass null to skip thumbnail uploading
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
     /// Video to be sent
     public let video: InputFile
@@ -461,13 +461,13 @@ public struct InputMessageVideo: Codable, Equatable, Hashable {
 
     public init(
         addedStickerFileIds: [Int],
-        caption: FormattedText,
+        caption: FormattedText?,
         duration: Int,
         hasSpoiler: Bool,
         height: Int,
         selfDestructTime: Int,
         supportsStreaming: Bool,
-        thumbnail: InputThumbnail,
+        thumbnail: InputThumbnail?,
         video: InputFile,
         width: Int
     ) {
@@ -494,7 +494,7 @@ public struct InputMessageVideoNote: Codable, Equatable, Hashable {
     public let length: Int
 
     /// Video thumbnail; pass null to skip thumbnail uploading
-    public let thumbnail: InputThumbnail
+    public let thumbnail: InputThumbnail?
 
     /// Video note to be sent
     public let videoNote: InputFile
@@ -503,7 +503,7 @@ public struct InputMessageVideoNote: Codable, Equatable, Hashable {
     public init(
         duration: Int,
         length: Int,
-        thumbnail: InputThumbnail,
+        thumbnail: InputThumbnail?,
         videoNote: InputFile
     ) {
         self.duration = duration
@@ -517,7 +517,7 @@ public struct InputMessageVideoNote: Codable, Equatable, Hashable {
 public struct InputMessageVoiceNote: Codable, Equatable, Hashable {
 
     /// Voice note caption; pass null to use an empty caption; 0-getOption("message_caption_length_max") characters
-    public let caption: FormattedText
+    public let caption: FormattedText?
 
     /// Duration of the voice note, in seconds
     public let duration: Int
@@ -530,7 +530,7 @@ public struct InputMessageVoiceNote: Codable, Equatable, Hashable {
 
 
     public init(
-        caption: FormattedText,
+        caption: FormattedText?,
         duration: Int,
         voiceNote: InputFile,
         waveform: Data
@@ -749,7 +749,7 @@ public struct InputMessagePoll: Codable, Equatable, Hashable {
 public struct InputMessageForwarded: Codable, Equatable, Hashable {
 
     /// Options to be used to copy content of the message without reference to the original sender; pass null to forward the message as usual
-    public let copyOptions: MessageCopyOptions
+    public let copyOptions: MessageCopyOptions?
 
     /// Identifier for the chat this forwarded message came from
     public let fromChatId: Int64
@@ -762,7 +762,7 @@ public struct InputMessageForwarded: Codable, Equatable, Hashable {
 
 
     public init(
-        copyOptions: MessageCopyOptions,
+        copyOptions: MessageCopyOptions?,
         fromChatId: Int64,
         inGameShare: Bool,
         messageId: Int64

--- a/Sources/TDLibKit/Generated/Models/InputSticker.swift
+++ b/Sources/TDLibKit/Generated/Models/InputSticker.swift
@@ -20,7 +20,7 @@ public struct InputSticker: Codable, Equatable, Hashable {
     public let keywords: [String]
 
     /// Position where the mask is placed; pass null if not specified
-    public let maskPosition: MaskPosition
+    public let maskPosition: MaskPosition?
 
     /// File with the sticker; must fit in a 512x512 square. For WEBP stickers the file must be in WEBP or PNG format, which will be converted to WEBP server-side.//-See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
     public let sticker: InputFile
@@ -29,7 +29,7 @@ public struct InputSticker: Codable, Equatable, Hashable {
     public init(
         emojis: String,
         keywords: [String],
-        maskPosition: MaskPosition,
+        maskPosition: MaskPosition?,
         sticker: InputFile
     ) {
         self.emojis = emojis

--- a/Sources/TDLibKit/Generated/Models/LanguagePackString.swift
+++ b/Sources/TDLibKit/Generated/Models/LanguagePackString.swift
@@ -17,12 +17,12 @@ public struct LanguagePackString: Codable, Equatable, Hashable {
     public let key: String
 
     /// String value; pass null if the string needs to be taken from the built-in English language pack
-    public let value: LanguagePackStringValue
+    public let value: LanguagePackStringValue?
 
 
     public init(
         key: String,
-        value: LanguagePackStringValue
+        value: LanguagePackStringValue?
     ) {
         self.key = key
         self.value = value

--- a/Sources/TDLibKit/Generated/Models/MessageCopyOptions.swift
+++ b/Sources/TDLibKit/Generated/Models/MessageCopyOptions.swift
@@ -14,7 +14,7 @@ import Foundation
 public struct MessageCopyOptions: Codable, Equatable, Hashable {
 
     /// New message caption; pass null to copy message without caption. Ignored if replace_caption is false
-    public let newCaption: FormattedText
+    public let newCaption: FormattedText?
 
     /// True, if media caption of the message copy needs to be replaced. Ignored if send_copy is false
     public let replaceCaption: Bool
@@ -24,7 +24,7 @@ public struct MessageCopyOptions: Codable, Equatable, Hashable {
 
 
     public init(
-        newCaption: FormattedText,
+        newCaption: FormattedText?,
         replaceCaption: Bool,
         sendCopy: Bool
     ) {

--- a/Sources/TDLibKit/Generated/Models/MessageSendOptions.swift
+++ b/Sources/TDLibKit/Generated/Models/MessageSendOptions.swift
@@ -23,7 +23,7 @@ public struct MessageSendOptions: Codable, Equatable, Hashable {
     public let protectContent: Bool
 
     /// Message scheduling state; pass null to send message immediately. Messages sent to a secret chat, live location messages and self-destructing messages can't be scheduled
-    public let schedulingState: MessageSchedulingState
+    public let schedulingState: MessageSchedulingState?
 
     /// Non-persistent identifier, which will be returned back in messageSendingStatePending object and can be used to match sent messages and corresponding updateNewMessage updates
     public let sendingId: Int
@@ -36,7 +36,7 @@ public struct MessageSendOptions: Codable, Equatable, Hashable {
         disableNotification: Bool,
         fromBackground: Bool,
         protectContent: Bool,
-        schedulingState: MessageSchedulingState,
+        schedulingState: MessageSchedulingState?,
         sendingId: Int,
         updateOrderOfInstalledStickerSets: Bool
     ) {

--- a/Sources/TDLibKit/Generated/Models/NetworkStatisticsEntry.swift
+++ b/Sources/TDLibKit/Generated/Models/NetworkStatisticsEntry.swift
@@ -55,7 +55,7 @@ public enum NetworkStatisticsEntry: Codable, Equatable, Hashable {
 public struct NetworkStatisticsEntryFile: Codable, Equatable, Hashable {
 
     /// Type of the file the data is part of; pass null if the data isn't related to files
-    public let fileType: FileType
+    public let fileType: FileType?
 
     /// Type of the network the data was sent through. Call setNetworkType to maintain the actual network type
     public let networkType: NetworkType
@@ -68,7 +68,7 @@ public struct NetworkStatisticsEntryFile: Codable, Equatable, Hashable {
 
 
     public init(
-        fileType: FileType,
+        fileType: FileType?,
         networkType: NetworkType,
         receivedBytes: Int64,
         sentBytes: Int64

--- a/Sources/TDLibKit/Generated/Models/PhoneNumberAuthenticationSettings.swift
+++ b/Sources/TDLibKit/Generated/Models/PhoneNumberAuthenticationSettings.swift
@@ -26,7 +26,7 @@ public struct PhoneNumberAuthenticationSettings: Codable, Equatable, Hashable {
     public let authenticationTokens: [String]
 
     /// For official Android and iOS applications only; pass null otherwise. Settings for Firebase Authentication
-    public let firebaseAuthenticationSettings: FirebaseAuthenticationSettings
+    public let firebaseAuthenticationSettings: FirebaseAuthenticationSettings?
 
     /// Pass true if the authenticated phone number is used on the current device
     public let isCurrentPhoneNumber: Bool
@@ -37,7 +37,7 @@ public struct PhoneNumberAuthenticationSettings: Codable, Equatable, Hashable {
         allowMissedCall: Bool,
         allowSmsRetrieverApi: Bool,
         authenticationTokens: [String],
-        firebaseAuthenticationSettings: FirebaseAuthenticationSettings,
+        firebaseAuthenticationSettings: FirebaseAuthenticationSettings?,
         isCurrentPhoneNumber: Bool
     ) {
         self.allowFlashCall = allowFlashCall

--- a/scripts/tl2swift/Sources/TlParserLib/Parser/Parser.swift
+++ b/scripts/tl2swift/Sources/TlParserLib/Parser/Parser.swift
@@ -83,9 +83,11 @@ public final class Parser {
                 for (name, type) in entityNameAndTypes.types {
                     let desc = entityDesc.params[name]
                     // Any direct or indirect function parameter can be specified to be null.
-                    // In all function null objects are allowed by TDLib in incoming requests.
+                    // In all functions null objects are allowed by TDLib in incoming requests.
                     // https://github.com/tdlib/td/issues/1536
-                    let optional = (desc?.contains("may be null") ?? false) || hitFunctions
+                    let optional = (desc?.contains("may be null") ?? false) ||
+                        (desc?.contains("pass null") ?? false) ||
+                        hitFunctions
                     let prop = ClassProperty(name: name, type: type, description: desc, optional: optional)
                     properties.append(prop)
                 }


### PR DESCRIPTION
Detect parameters that have "pass null" in their description similar to how "may be null" is detected. These are now correctly marked as optional.

For example, here:

```swift

/// Options to be used when a message is sent
public struct MessageSendOptions: Codable, Equatable, Hashable {

    ...

    /// Message scheduling state; pass null to send message immediately. Messages sent to a secret chat, live location messages and self-destructing messages can't be scheduled
    public let schedulingState: MessageSchedulingState? 👈

    ...
}
```