### PR TITLE
Fix TdInt64 JSON type for inline keyboard test helper

### DIFF
--- a/Tests/TDLibKitTests/TDLibKitTests.swift
+++ b/Tests/TDLibKitTests/TDLibKitTests.swift
@@ -116,7 +116,7 @@ class TDLibKitUnitTests: XCTestCase {
         var json: [String: Any] = [
             "@type": "inlineKeyboardButton",
             "text": text,
-            "icon_custom_emoji_id": 0,
+            "icon_custom_emoji_id": "0",
             "style": ["@type": "buttonStyleDefault"],
             "type": ["@type": type]
         ]


### PR DESCRIPTION
## Summary
- fix `makeInlineKeyboardButton` test helper to encode `icon_custom_emoji_id` as a string (`\"0\"`) instead of a numeric literal
- match TDLib `TdInt64` decoding behavior in generated models, which expects JSON string values
- resolve CI crash in unit tests with `DecodingError.typeMismatch(String, ...)`